### PR TITLE
styling changes

### DIFF
--- a/src/components/add-item/AddItem.jsx
+++ b/src/components/add-item/AddItem.jsx
@@ -54,7 +54,7 @@ const AddItem = () => {
   };
 
   return (
-    <div className="add-item-container">
+    <div className="add-item-container" style={{position: "fixed"}}>
       <h2>Add New Book</h2>
       <div className="input-group">
         <label htmlFor="title">Title:</label>

--- a/src/components/add-patron/AddPatron.jsx
+++ b/src/components/add-patron/AddPatron.jsx
@@ -1,6 +1,6 @@
 
 const AddPatron = () => {
-    return <div>AddPatron</div>
+    return <div style={{position: "fixed"}}>AddPatron</div>
 };
 
 export default AddPatron; 

--- a/src/components/checkin/Checkin.jsx
+++ b/src/components/checkin/Checkin.jsx
@@ -1,6 +1,6 @@
 
 const Checkin = () => {
-    return <div>Checkin</div>
+    return <div style={{position: "fixed"}}>Checkin</div>
 };
 
 export default Checkin; 

--- a/src/components/checkout/Checkout.jsx
+++ b/src/components/checkout/Checkout.jsx
@@ -172,7 +172,7 @@ const Checkout = () => {
   };
 
   return (
-    <div className="checkout-container">
+    <div className="checkout-container" style={{position: "fixed"}}>
       <h2>Book Checkout</h2>
       <div className="input-group">
         <label htmlFor="customerId">Customer ID:</label>

--- a/src/components/dashboard/Dashboard.css
+++ b/src/components/dashboard/Dashboard.css
@@ -26,6 +26,7 @@ table {
     margin: 10px;
     position: relative; 
     overflow: auto; 
+    z-index: 0;
 }
 
 .view-checkout {

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,5 +1,6 @@
 // import { blue } from "@mui/material/colors";
 
+
 const Header = () => {
     const headerStyle = {
         color: "blue",
@@ -9,8 +10,16 @@ const Header = () => {
         letterSpacing: "0.05em",
         boxShadow: "0 4px 8px 0 rgba(0, 0, 0, 0.2)",
         paddingBottom: "15px",
-        position: "fixed",
-        width: "100vw"
+        position: "sticky",
+        top: "0",
+        left: "50%",
+        width: "100vw",
+        height: "35px",
+        zIndex: "2",
+        backgroundColor: "white",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
     };
 
     return (

--- a/src/components/manage-fines/ManageFines.jsx
+++ b/src/components/manage-fines/ManageFines.jsx
@@ -1,6 +1,6 @@
 
 const ManageFines = () => {
-    return <div>ManageFines</div>
+    return <div style={{position: "fixed"}}>ManageFines</div>
 };
 
 export default ManageFines; 

--- a/src/components/navigation/Navigation.jsx
+++ b/src/components/navigation/Navigation.jsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import { menuItems } from '../../utils/constant';
 import { useState, useEffect } from 'react';
+import zIndex from '@mui/material/styles/zIndex';
 
 const Navigation = () => {
   const [selectedPath, setSelectedPath] = useState(window.location.pathname); // Initial selected path
@@ -22,6 +23,7 @@ const Navigation = () => {
     paddingBottom: '10px',
     paddingLeft: '10px',
     textAlign: 'left',
+    zIndex: "3",
   };
 
   const ListItemStyle = {

--- a/src/components/search-bar/SearchBar.css
+++ b/src/components/search-bar/SearchBar.css
@@ -3,7 +3,10 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    /* height: 10vh; */
+    position: "fixed";
+    top: "35px";
+    left: "50%";
+     /* height: 10vh; */
   }
   
   .search-bar {


### PR DESCRIPTION
added fixed positions to all component pages except dashboard (allows dashboard to scroll horizontally for overflow columns while preventing scroll on the other elements)

header now appears at the top of the screen, search bar appears below that, then the content below that.

search bar disappears on vertical scroll; not sure how to fix that

added a z-index to header, dashboard, and navbar so that when dashboard is scrolled, the content does not cover the other two elements